### PR TITLE
標準入力仕様のキャンセル

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 
@@ -40,6 +39,9 @@ func ask(args []string, logger *slog.Logger) error {
 	path := ""
 	if len(args) != 0 {
 		path = args[0]
+	}
+	if path == "" {
+		return fmt.Errorf("file path is required")
 	}
 	content, err := loadContent(path)
 	if err != nil {
@@ -77,35 +79,23 @@ func ask(args []string, logger *slog.Logger) error {
 	logger.Info("cost information", "costInfo", costInfo)
 	answer := resp.Choices[0].Message.Content
 
-	if path != "" {
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
-		appendText := fmt.Sprintf("\n\n%s\n", answer)
-		if _, err := f.WriteString(appendText); err != nil {
-			return err
-		}
-	} else {
-		fmt.Println(answer)
+	appendText := fmt.Sprintf("\n\n%s\n", answer)
+	if _, err := f.WriteString(appendText); err != nil {
+		return err
 	}
 	return nil
 }
 
 func loadContent(path string) (string, error) {
-	if path != "" {
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return "", err
-		}
-		return string(b), nil
-	} else {
-		b, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return "", fmt.Errorf("error reading from standard input: %v", err)
-		}
-		return string(b), nil
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
 	}
+	return string(b), nil
 }


### PR DESCRIPTION
This pull request refactors the `ask` command in `cmd/ask.go` to simplify its logic and improve error handling. The main change is to require a file path argument and remove support for reading from standard input, which streamlines the code and makes its behavior more predictable.

Error handling and input validation:

* The `ask` command now requires a file path argument and returns an error if it is missing, improving input validation and preventing ambiguous usage.

Simplification of file handling logic:

* Removed conditional logic for reading from standard input; the command now always reads from the specified file path, simplifying the implementation and reducing potential sources of error. [[1]](diffhunk://#diff-76aec1ebb238ed4f453898f74b940a865fac7fe410fa000a20bf9e0ccb5ea011L91-L110) [[2]](diffhunk://#diff-76aec1ebb238ed4f453898f74b940a865fac7fe410fa000a20bf9e0ccb5ea011L9)

Streamlined answer writing:

* The code for appending the answer to the file has been simplified by removing the conditional check for an empty path, as the path is now always required.