### PR TITLE
翻訳コマンドの実装

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,57 +1,57 @@
-# インストールとセットアップ
+# Installation and Setup
 
-このドキュメントでは、mdaiのインストールとセットアップについて詳しく説明します。
+This document provides detailed instructions on installing and setting up mdai.
 
-## 📋 前提条件
+## 📋 Prerequisites
 
-- Go 1.22.0以上
-- OpenAI APIキー
+- Go version 1.22.0 or higher
+- OpenAI API key
     - see: https://platform.openai.com/api-keys
 
-## 🛠️ インストール
+## 🛠️ Installation
 
-### 方法1: go installを使用（推奨）
+### Method 1: Using `go install` (Recommended)
 
 ```bash
 go install github.com/koooyooo/mdai@latest
 ```
 
-### 方法2: ソースからビルド
+### Method 2: Building from Source
 
-#### 1. リポジトリのクローン
+#### 1. Clone the Repository
 
 ```bash
 $ git clone https://github.com/koooyooo/mdai.git
 $ cd mdai
 ```
 
-#### 2. 依存関係のインストール
+#### 2. Install Dependencies
 
 ```bash
 $ go mod download
 ```
 
-#### 3. ビルド
+#### 3. Build
 
 ```bash
 $ go build -o mdai
 ```
 
-#### 4. 実行可能ファイルをPATHに追加（オプション）
+#### 4. (Optional) Add the Executable to PATH
 
 ```bash
 # macOS/Linux
 $ sudo cp mdai /usr/local/bin/
 
 # Windows
-# mdai.exeを適切なディレクトリにコピー
+# Copy mdai.exe to an appropriate directory
 ```
 
-## 🔑 セットアップ
+## 🔑 Setup
 
-### OpenAI APIキーの設定
+### Setting the OpenAI API Key
 
-環境変数にOpenAI APIキーを設定してください：
+Please set the OpenAI API key in your environment variables:
 
 ```bash
 # macOS/Linux
@@ -61,44 +61,44 @@ export OPENAI_API_KEY="your-api-key-here"
 set OPENAI_API_KEY=your-api-key-here
 ```
 
-または、`.bashrc`や`.zshrc`に追加して永続化：
+Alternatively, you can add it to `.bashrc` or `.zshrc` for persistence:
 
 ```bash
 echo 'export OPENAI_API_KEY="your-api-key-here"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-## ✅ インストール確認
+## ✅ Verifying the Installation
 
-インストールが完了したかどうかを確認するには：
+To check if the installation was successful:
 
 ```bash
 mdai --version
 ```
 
-または
+Or
 
 ```bash
 mdai --help
 ```
 
-## 🚨 トラブルシューティング
+## 🚨 Troubleshooting
 
-### よくある問題
+### Common Issues
 
-1. **コマンドが見つからない**
-   - GoのPATHが正しく設定されているか確認
-   - `go env GOPATH`でGoのパスを確認
+1. **Command not found**
+   - Ensure the Go PATH is set correctly
+   - Check the Go path using `go env GOPATH`
 
-2. **APIキーが認識されない**
-   - 環境変数が正しく設定されているか確認
-   - ターミナルを再起動して環境変数を再読み込み
+2. **API key not recognized**
+   - Ensure the environment variable is set correctly
+   - Restart the terminal to reload the environment variable
 
-3. **権限エラー**
-   - 実行可能ファイルに実行権限があるか確認
-   - `chmod +x mdai`で権限を付与
+3. **Permission errors**
+   - Check if the executable has execution permissions
+   - Grant permissions using `chmod +x mdai`
 
-## 🔗 関連リンク
+## 🔗 Related Links
 
-- [README.md](README.md) - プロジェクト概要と使用方法
-- [LICENSE](LICENSE) - ライセンス情報
+- [README.md](README.md) - Project overview and usage instructions
+- [LICENSE](LICENSE) - License information

--- a/INSTALL_ja.md
+++ b/INSTALL_ja.md
@@ -1,0 +1,104 @@
+# インストールとセットアップ
+
+このドキュメントでは、mdaiのインストールとセットアップについて詳しく説明します。
+
+## 📋 前提条件
+
+- Go 1.22.0以上
+- OpenAI APIキー
+    - see: https://platform.openai.com/api-keys
+
+## 🛠️ インストール
+
+### 方法1: go installを使用（推奨）
+
+```bash
+go install github.com/koooyooo/mdai@latest
+```
+
+### 方法2: ソースからビルド
+
+#### 1. リポジトリのクローン
+
+```bash
+$ git clone https://github.com/koooyooo/mdai.git
+$ cd mdai
+```
+
+#### 2. 依存関係のインストール
+
+```bash
+$ go mod download
+```
+
+#### 3. ビルド
+
+```bash
+$ go build -o mdai
+```
+
+#### 4. 実行可能ファイルをPATHに追加（オプション）
+
+```bash
+# macOS/Linux
+$ sudo cp mdai /usr/local/bin/
+
+# Windows
+# mdai.exeを適切なディレクトリにコピー
+```
+
+## 🔑 セットアップ
+
+### OpenAI APIキーの設定
+
+環境変数にOpenAI APIキーを設定してください：
+
+```bash
+# macOS/Linux
+export OPENAI_API_KEY="your-api-key-here"
+
+# Windows
+set OPENAI_API_KEY=your-api-key-here
+```
+
+または、`.bashrc`や`.zshrc`に追加して永続化：
+
+```bash
+echo 'export OPENAI_API_KEY="your-api-key-here"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## ✅ インストール確認
+
+インストールが完了したかどうかを確認するには：
+
+```bash
+mdai --version
+```
+
+または
+
+```bash
+mdai --help
+```
+
+## 🚨 トラブルシューティング
+
+### よくある問題
+
+1. **コマンドが見つからない**
+   - GoのPATHが正しく設定されているか確認
+   - `go env GOPATH`でGoのパスを確認
+
+2. **APIキーが認識されない**
+   - 環境変数が正しく設定されているか確認
+   - ターミナルを再起動して環境変数を再読み込み
+
+3. **権限エラー**
+   - 実行可能ファイルに実行権限があるか確認
+   - `chmod +x mdai`で権限を付与
+
+## 🔗 関連リンク
+
+- [README.md](README.md) - プロジェクト概要と使用方法
+- [LICENSE](LICENSE) - ライセンス情報

--- a/README.md
+++ b/README.md
@@ -1,179 +1,195 @@
 # mdai
 
-Markdownファイルの内容をAIに質問し、回答を自動で追記するCLIツールです。
+This is a CLI tool that allows you to ask questions about the contents of a Markdown file to an AI and automatically append the answers.
 
-## 🚀 機能
+## 🚀 Features
 
-- **AI質問**: Markdownファイルの引用部分を抽出してAIに質問
-- **自動追記**: AIの回答を元のファイルに自動で追記
-- **コスト計算**: OpenAI APIの使用コストを自動計算
-- **AI質問**: OpenAIのGPTモデルを使用して質問に回答
-- **クロスプラットフォーム**: Windows、macOS、Linuxで動作
+- **AI Questions**: Extracts quoted parts from the Markdown file to ask the AI
+- **Automatic Append**: Automatically appends the AI's answers to the original file
+- **Cost Calculation**: Automatically calculates the usage cost of the OpenAI API
+- **AI Answers**: Uses OpenAI's GPT model to respond to questions
+- **AI Translation**: Translates the Markdown file to a specified language
+- **Cross-Platform**: Works on Windows, macOS, and Linux
 
-## 📋 前提条件
+## 📋 Prerequisites
 
-- Go 1.22.0以上
-- OpenAI APIキー
+- Go 1.22.0 or higher
+- OpenAI API key
     - see: https://platform.openai.com/api-keys
 
-詳細なインストールとセットアップ手順は [INSTALL.md](INSTALL.md) を参照してください。
+For detailed installation and setup instructions, please refer to [INSTALL.md](INSTALL.md).
 
-## 📖 使用方法
+## 📖 Usage
 
-### 基本的な使用方法
+### Basic Usage
 
 ```bash
-# 設定ファイルの初期化（初回のみ）
+# Initialize the configuration file (only on first use)
 mdai init
 
-# Markdownファイルの引用部分をAIに質問
+# Ask the AI about quoted parts of the Markdown file
 mdai answer path/to/your/file.md
 
-# Markdownファイルの内容を要約
+# Summarize the contents of the Markdown file
 mdai summarize path/to/your/file.md
+
+# Translate the Markdown file to a specified language
+mdai translate path/to/your/file.md ja
 ```
 
-### 設定ファイルのカスタマイズ
+### Customizing the Configuration File
 
-mdaiは設定ファイルを使用して動作をカスタマイズできます。設定ファイルは `~/.mdai/config.yml` に配置されます。
+mdai can use a configuration file to customize its operation. The configuration file is located at `~/.mdai/config.yml`.
 
-#### 設定ファイルの初期化
+#### Initializing the Configuration File
 
 ```bash
-# 設定ファイルを初期化（初回セットアップ）
+# Initialize the configuration file (first setup)
 mdai init
 ```
 
-このコマンドは以下を実行します：
-1. `~/.mdai` ディレクトリを作成
-2. `config.sample.yml` を `~/.mdai/config.yml` にコピー
-3. 設定ファイルのパスを表示
+This command performs the following actions:
+1. Creates the `~/.mdai` directory
+2. Copies `config.sample.yml` to `~/.mdai/config.yml`
+3. Displays the path to the configuration file
 
-#### 設定項目
+#### Configuration Items
 
-- **デフォルト設定**: AIモデル、品質設定、ログレベル
-- **answerコマンド**: システムメッセージ、目標文字数
-- **summarizeコマンド**: システムメッセージ、目標文字数
+- **Default Settings**: AI model, quality settings, log level
+- **answer Command**: System message, target character count
+- **summarize Command**: System message, target character count
+- **translate Command**: System message
 
-詳細な設定例は `config/config.sample.yml` を参照してください。
+For detailed configuration examples, refer to `config/config.sample.yml`.
 
-### 使用例
+### Usage Example
 
-1. **Markdownファイルの準備**
+1. **Prepare the Markdown File**
 
 ```markdown
-# AI学習メモ
+# AI Learning Notes
 
-> AIを学ぶにあたってコツはありますか？
+> Are there any tips for learning AI?
 
-ここに既存の内容があれば、AIの回答が追記されます。
+If there is existing content here, the AI's answer will be appended.
 ```
 
-2. **AIに質問**
+2. **Ask the AI**
 
 ```bash
 mdai answer ai_learning.md
 ```
 
-3. **結果**
+3. **Result**
 
 ```markdown
-# AI学習メモ
+# AI Learning Notes
 
-> AIを学ぶにあたってコツはありますか？
+> Are there any tips for learning AI?
 
-ここに既存の内容があれば、AIの回答が追記されます。
+If there is existing content here, the AI's answer will be appended.
 
-AIを学ぶにあたってのコツはいくつかあります。まず、基礎知識をしっかりと固めることが重要です...
+There are several tips for learning AI. First, it is important to solidify your foundational knowledge...
 ```
 
-## 💰 コスト計算
+### Translation Example
 
-mdaiは自動的にAPI使用コストを計算し、ログに表示します。現在使用されているモデルの価格：
+```bash
+# Translate to English
+mdai translate ai_learning.md en
 
-- **GPT-4o-mini**: $0.15/1M input, $0.60/1M output（デフォルト）
+# Translate to Japanese
+mdai translate ai_learning.md ja
+```
+
+The translation results will be saved as `ai_learning_en.md` and `ai_learning_ja.md`.
+
+## 💰 Cost Calculation
+
+mdai automatically calculates API usage costs and displays them in the logs. Current model prices are as follows:
+
+- **GPT-4o-mini**: $0.15/1M input, $0.60/1M output (default)
 - **GPT-4o**: $2.50/1M input, $10.00/1M output
 - **GPT-4 Turbo**: $10.00/1M input, $30.00/1M output
 - **GPT-3.5-turbo**: $0.50/1M input, $1.50/1M output
 
-**注意**: 現在の実装では、GPT-4o-miniがデフォルトモデルとして使用されています。
+**Note**: Currently, the default model being used is GPT-4o-mini.
 
-
-## 🏗️ プロジェクト構造
+## 🏗️ Project Structure
 
 ```
 mdai/
-├── cmd/           # CLIコマンド
-│   ├── answer.go     # answerコマンドの実装
-│   ├── summarize.go  # summarizeコマンドの実装
-│   ├── init.go       # initコマンドの実装
-│   └── root.go       # ルートコマンド
-├── config/        # 設定ファイル
-│   └── config.go     # 設定構造体と読み込み処理
-├── config.sample.yml # サンプル設定ファイル
-├── controller/    # AI制御
-│   └── controller.go # OpenAI API制御
-├── models/        # AIモデル関連
-│   ├── ai_model.go    # AIモデルの定義
-│   ├── constants.go    # モデル定数
-│   └── helpers.go      # ヘルパー関数
-├── util/          # ユーティリティ
-│   └── file/      # ファイル操作
-├── mdai.go        # エントリーポイント
-└── go.mod         # Goモジュール定義
+├── cmd/           # CLI commands
+│   ├── answer.go     # Implementation of the answer command
+│   ├── summarize.go  # Implementation of the summarize command
+│   ├── translate.go  # Implementation of the translate command
+│   ├── init.go       # Implementation of the init command
+│   └── root.go       # Root command
+├── config/        # Configuration files
+│   └── config.go     # Configuration struct and loading process
+├── config.sample.yml # Sample configuration file
+├── controller/    # AI control
+│   └── controller.go # OpenAI API control
+├── models/        # AI model related
+│   ├── ai_model.go    # Definition of AI models
+│   ├── constants.go    # Model constants
+│   └── helpers.go      # Helper functions
+├── util/          # Utilities
+│   └── file/      # File operations
+├── mdai.go        # Entry point
+└── go.mod         # Go module definition
 ```
 
-## 🔧 開発
+## 🔧 Development
 
-### 依存関係の追加
+### Adding Dependencies
 
 ```bash
 go get github.com/package-name
 ```
 
-### テストの実行
+### Running Tests
 
 ```bash
 go test ./...
 ```
 
-### リントの実行
+### Running Lint
 
 ```bash
-# golangci-lintがインストールされている場合
+# If golangci-lint is installed
 golangci-lint run
 ```
 
-## 📝 ライセンス
+## 📝 License
 
-このプロジェクトはMITライセンスの下で公開されています。詳細は[LICENSE](LICENSE)ファイルを参照してください。
+This project is licensed under the MIT License. Please refer to the [LICENSE](LICENSE) file for details.
 
-## 🤝 コントリビューション
+## 🤝 Contribution
 
-プルリクエストやイシューの報告を歓迎します！
+Pull requests and issue reports are welcome!
 
-1. このリポジトリをフォーク
-2. 機能ブランチを作成 (`git checkout -b feature/amazing-feature`)
-3. 変更をコミット (`git commit -m 'Add some amazing feature'`)
-4. ブランチにプッシュ (`git push origin feature/amazing-feature`)
-5. プルリクエストを作成
+1. Fork this repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Create a pull request
 
-### 🚧 開発状況
+### 🚧 Development Status
 
-現在、以下の機能が実装されています：
-- OpenAI GPTモデルを使用した質問回答
-- Markdownファイルの引用抽出と回答追記
-- コスト計算機能
+Currently, the following features have been implemented:
+- Question answering using OpenAI GPT models
+- Extraction of quoted parts from Markdown files and appending answers
+- Cost calculation feature
 
-今後の開発予定：
-- モデル選択機能の追加
-- 他のAIプロバイダー（Claude等）への対応
-- 設定ファイルによるカスタマイズ
+Planned developments include:
+- Adding a model selection feature
+- Support for other AI providers (e.g., Claude)
+- Customization through configuration files
 
-**注意**: このツールを使用する際は、OpenAI APIの利用規約と料金体系を確認してください。
+**Note**: Please check the OpenAI API terms of service and pricing structure when using this tool.
 
-## 🔗 関連リンク
+## 🔗 Related Links
 
-- [INSTALL.md](INSTALL.md) - インストールとセットアップ手順
-- [LICENSE](LICENSE) - ライセンス情報
-
+- [INSTALL.md](INSTALL.md) - Installation and setup instructions
+- [LICENSE](LICENSE) - License information

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,197 @@
+# mdai
+
+Markdownファイルの内容をAIに質問し、回答を自動で追記するCLIツールです。
+
+## 🚀 機能
+
+- **AI質問**: Markdownファイルの引用部分を抽出してAIに質問
+- **自動追記**: AIの回答を元のファイルに自動で追記
+- **コスト計算**: OpenAI APIの使用コストを自動計算
+- **AI質問**: OpenAIのGPTモデルを使用して質問に回答
+- **AI翻訳**: Markdownファイルを指定言語に翻訳
+- **クロスプラットフォーム**: Windows、macOS、Linuxで動作
+
+## 📋 前提条件
+
+- Go 1.22.0以上
+- OpenAI APIキー
+    - see: https://platform.openai.com/api-keys
+
+詳細なインストールとセットアップ手順は [INSTALL.md](INSTALL.md) を参照してください。
+
+## 📖 使用方法
+
+### 基本的な使用方法
+
+```bash
+# 設定ファイルの初期化（初回のみ）
+mdai init
+
+# Markdownファイルの引用部分をAIに質問
+mdai answer path/to/your/file.md
+
+# Markdownファイルの内容を要約
+mdai summarize path/to/your/file.md
+
+# Markdownファイルを指定言語に翻訳
+mdai translate path/to/your/file.md ja
+```
+
+### 設定ファイルのカスタマイズ
+
+mdaiは設定ファイルを使用して動作をカスタマイズできます。設定ファイルは `~/.mdai/config.yml` に配置されます。
+
+#### 設定ファイルの初期化
+
+```bash
+# 設定ファイルを初期化（初回セットアップ）
+mdai init
+```
+
+このコマンドは以下を実行します：
+1. `~/.mdai` ディレクトリを作成
+2. `config.sample.yml` を `~/.mdai/config.yml` にコピー
+3. 設定ファイルのパスを表示
+
+#### 設定項目
+
+- **デフォルト設定**: AIモデル、品質設定、ログレベル
+- **answerコマンド**: システムメッセージ、目標文字数
+- **summarizeコマンド**: システムメッセージ、目標文字数
+- **translateコマンド**: システムメッセージ
+
+詳細な設定例は `config/config.sample.yml` を参照してください。
+
+### 使用例
+
+1. **Markdownファイルの準備**
+
+```markdown
+# AI学習メモ
+
+> AIを学ぶにあたってコツはありますか？
+
+ここに既存の内容があれば、AIの回答が追記されます。
+```
+
+2. **AIに質問**
+
+```bash
+mdai answer ai_learning.md
+```
+
+3. **結果**
+
+```markdown
+# AI学習メモ
+
+> AIを学ぶにあたってコツはありますか？
+
+ここに既存の内容があれば、AIの回答が追記されます。
+
+AIを学ぶにあたってのコツはいくつかあります。まず、基礎知識をしっかりと固めることが重要です...
+
+### 翻訳の例
+
+```bash
+# 英語に翻訳
+mdai translate ai_learning.md en
+
+# 日本語に翻訳
+mdai translate ai_learning.md ja
+```
+
+翻訳結果は `ai_learning_en.md`、`ai_learning_ja.md` として保存されます。
+```
+
+## 💰 コスト計算
+
+mdaiは自動的にAPI使用コストを計算し、ログに表示します。現在使用されているモデルの価格：
+
+- **GPT-4o-mini**: $0.15/1M input, $0.60/1M output（デフォルト）
+- **GPT-4o**: $2.50/1M input, $10.00/1M output
+- **GPT-4 Turbo**: $10.00/1M input, $30.00/1M output
+- **GPT-3.5-turbo**: $0.50/1M input, $1.50/1M output
+
+**注意**: 現在の実装では、GPT-4o-miniがデフォルトモデルとして使用されています。
+
+
+## 🏗️ プロジェクト構造
+
+```
+mdai/
+├── cmd/           # CLIコマンド
+│   ├── answer.go     # answerコマンドの実装
+│   ├── summarize.go  # summarizeコマンドの実装
+│   ├── translate.go  # translateコマンドの実装
+│   ├── init.go       # initコマンドの実装
+│   └── root.go       # ルートコマンド
+├── config/        # 設定ファイル
+│   └── config.go     # 設定構造体と読み込み処理
+├── config.sample.yml # サンプル設定ファイル
+├── controller/    # AI制御
+│   └── controller.go # OpenAI API制御
+├── models/        # AIモデル関連
+│   ├── ai_model.go    # AIモデルの定義
+│   ├── constants.go    # モデル定数
+│   └── helpers.go      # ヘルパー関数
+├── util/          # ユーティリティ
+│   └── file/      # ファイル操作
+├── mdai.go        # エントリーポイント
+└── go.mod         # Goモジュール定義
+```
+
+## 🔧 開発
+
+### 依存関係の追加
+
+```bash
+go get github.com/package-name
+```
+
+### テストの実行
+
+```bash
+go test ./...
+```
+
+### リントの実行
+
+```bash
+# golangci-lintがインストールされている場合
+golangci-lint run
+```
+
+## 📝 ライセンス
+
+このプロジェクトはMITライセンスの下で公開されています。詳細は[LICENSE](LICENSE)ファイルを参照してください。
+
+## 🤝 コントリビューション
+
+プルリクエストやイシューの報告を歓迎します！
+
+1. このリポジトリをフォーク
+2. 機能ブランチを作成 (`git checkout -b feature/amazing-feature`)
+3. 変更をコミット (`git commit -m 'Add some amazing feature'`)
+4. ブランチにプッシュ (`git push origin feature/amazing-feature`)
+5. プルリクエストを作成
+
+### 🚧 開発状況
+
+現在、以下の機能が実装されています：
+- OpenAI GPTモデルを使用した質問回答
+- Markdownファイルの引用抽出と回答追記
+- コスト計算機能
+
+今後の開発予定：
+- モデル選択機能の追加
+- 他のAIプロバイダー（Claude等）への対応
+- 設定ファイルによるカスタマイズ
+
+**注意**: このツールを使用する際は、OpenAI APIの利用規約と料金体系を確認してください。
+
+## 🔗 関連リンク
+
+- [INSTALL.md](INSTALL.md) - インストールとセットアップ手順
+- [LICENSE](LICENSE) - ライセンス情報
+

--- a/cmd/answer.go
+++ b/cmd/answer.go
@@ -65,15 +65,15 @@ func answer(args []string, logger *slog.Logger) error {
 	temperature := cfg.Default.Quality.Temperature
 
 	// システムメッセージに文字数の指示を追加
-	if cfg.Answer.TargetChars > 0 {
-		sysMsg += fmt.Sprintf("\n\n**Answer Length Guidance**: Please provide an answer of approximately %d characters.", cfg.Answer.TargetChars)
+	if cfg.Answer.TargetLength > 0 {
+		sysMsg += fmt.Sprintf("\n\n**Answer Length Guidance**: Please provide an answer of approximately %d characters.", cfg.Answer.TargetLength)
 	}
 
 	// 設定値をログに出力
 	logger.Info("using configuration",
 		"maxTokens", maxTokens,
 		"temperature", temperature,
-		"targetChars", cfg.Answer.TargetChars)
+		"targetLength", cfg.Answer.TargetLength)
 
 	controller.Control(sysMsg, userMsg, cfg.Default.Quality, func(completion *openai.ChatCompletion) error {
 		answer := completion.Choices[0].Message.Content

--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/koooyooo/mdai/config"
 	"github.com/koooyooo/mdai/controller"
@@ -86,15 +85,15 @@ func summarize(args []string, logger *slog.Logger) error {
 	temperature := cfg.Default.Quality.Temperature
 
 	// システムメッセージに文字数の指示を追加
-	if cfg.Summarize.TargetChars > 0 {
-		sysMsg += fmt.Sprintf("\n\n**Summary Length Guidance**: Please provide a summary of approximately %d characters.", cfg.Summarize.TargetChars)
+	if cfg.Summarize.TargetLength > 0 {
+		sysMsg += fmt.Sprintf("\n\n**Summary Length Guidance**: Please provide a summary of approximately %d characters.", cfg.Summarize.TargetLength)
 	}
 
 	// 設定値をログに出力
 	logger.Info("using configuration",
 		"maxTokens", maxTokens,
 		"temperature", temperature,
-		"targetChars", cfg.Summarize.TargetChars)
+		"targetLength", cfg.Summarize.TargetLength)
 
 	controller.Control(sysMsg, userMsg, cfg.Default.Quality, func(completion *openai.ChatCompletion) error {
 		summary := completion.Choices[0].Message.Content
@@ -143,15 +142,6 @@ Please create a well-structured summary that captures the essence and key points
 }
 
 func saveSummary(outputPath, summary, originalPath string) error {
-	// 要約ファイルのヘッダーを作成
-	header := fmt.Sprintf(`# Summary of: %s
-
-*Generated on: %s*
-
----
-
-`, filepath.Base(originalPath), getCurrentTimestamp())
-
 	// ファイルに書き込み
 	f, err := os.Create(outputPath)
 	if err != nil {
@@ -159,14 +149,10 @@ func saveSummary(outputPath, summary, originalPath string) error {
 	}
 	defer f.Close()
 
-	// ヘッダーと要約内容を書き込み
-	if _, err := f.WriteString(header + summary); err != nil {
+	// 要約内容を直接書き込み
+	if _, err := f.WriteString(summary); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func getCurrentTimestamp() string {
-	return time.Now().Format("2006-01-02 15:04:05")
 }

--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -1,0 +1,211 @@
+/*
+Copyright © 2025 koooyooo
+*/
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/koooyooo/mdai/config"
+	"github.com/koooyooo/mdai/controller"
+	"github.com/openai/openai-go"
+	"github.com/spf13/cobra"
+)
+
+// translateCmd represents the translate command
+var translateCmd = &cobra.Command{
+	Use:   "translate [filepath] [language]",
+	Short: "Translate markdown file to specified language",
+	Long: `Translate a markdown file to the specified language using AI.
+The translated content will be saved to a new file with "_[language]" suffix.
+For example, if the input file is "document.md" and language is "ja", 
+the output will be "document_ja.md".
+
+Supported language codes: "en", "ja", "zh", "ko", "es", "fr", "de", etc.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+		if err := translate(args, logger); err != nil {
+			logger.Error("fail in calling translate", "error", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(translateCmd)
+}
+
+func translate(args []string, logger *slog.Logger) error {
+	controller := controller.NewOpenAIController(os.Getenv("OPENAI_API_KEY"), logger)
+
+	if len(args) < 2 {
+		return fmt.Errorf("both filepath and language are required")
+	}
+	path := args[0]
+	language := args[1]
+
+	// ファイルの存在確認
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("file not found: %s", path)
+	}
+
+	// ファイル拡張子の確認
+	if !strings.HasSuffix(strings.ToLower(path), ".md") {
+		return fmt.Errorf("file must have .md extension: %s", path)
+	}
+
+	// 言語コードの検証
+	if !isValidLanguageCode(language) {
+		return fmt.Errorf("invalid language code: %s. Please use standard language codes like 'en', 'ja', 'zh', etc.", language)
+	}
+
+	// 出力ファイル名の生成
+	outputPath := generateTranslateOutputPath(path, language)
+
+	// ファイル内容の読み込み
+	content, err := loadContent(path)
+	if err != nil {
+		return fmt.Errorf("fail in loading content: %v", err)
+	}
+
+	// 設定ファイルを読み込み
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		logger.Warn("failed to load config, using defaults", "error", err)
+		// エラーが発生した場合はデフォルト設定を使用
+		cfg = config.GetDefaultConfig()
+	}
+
+	// 設定ファイルからシステムメッセージを取得
+	sysMsg := cfg.Translate.SystemMessage
+	if sysMsg == "" {
+		sysMsg = createTranslateSystemMessage()
+	}
+
+	// 言語固有の指示を追加
+	sysMsg += fmt.Sprintf("\n\n**Target Language**: %s", getLanguageName(language))
+
+	userMsg := createTranslateUserMessage(content, language)
+
+	// 設定ファイルから品質設定を取得
+	maxTokens := cfg.Default.Quality.MaxTokens
+	temperature := cfg.Default.Quality.Temperature
+
+	// 設定値をログに出力
+	logger.Info("using configuration",
+		"maxTokens", maxTokens,
+		"temperature", temperature,
+		"targetLanguage", language)
+
+	controller.Control(sysMsg, userMsg, cfg.Default.Quality, func(completion *openai.ChatCompletion) error {
+		translatedContent := completion.Choices[0].Message.Content
+
+		// 翻訳結果をファイルに保存
+		if err := saveTranslation(outputPath, translatedContent, path, language); err != nil {
+			return fmt.Errorf("fail in saving translation: %v", err)
+		}
+
+		logger.Info("translation created successfully", "input", path, "output", outputPath, "language", language)
+		return nil
+	})
+
+	return nil
+}
+
+func generateTranslateOutputPath(inputPath, language string) string {
+	dir := filepath.Dir(inputPath)
+	filename := filepath.Base(inputPath)
+	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
+	return filepath.Join(dir, nameWithoutExt+"_"+language+".md")
+}
+
+func isValidLanguageCode(language string) bool {
+	// 一般的な言語コードのリスト
+	validLanguages := map[string]bool{
+		"en": true, "ja": true, "zh": true, "ko": true, "es": true,
+		"fr": true, "de": true, "it": true, "pt": true, "ru": true,
+		"ar": true, "hi": true, "th": true, "vi": true, "nl": true,
+		"sv": true, "no": true, "da": true, "fi": true, "pl": true,
+		"tr": true, "he": true, "id": true, "ms": true, "ca": true,
+	}
+	return validLanguages[strings.ToLower(language)]
+}
+
+func getLanguageName(languageCode string) string {
+	languageNames := map[string]string{
+		"en": "English",
+		"ja": "Japanese (日本語)",
+		"zh": "Chinese (中文)",
+		"ko": "Korean (한국어)",
+		"es": "Spanish (Español)",
+		"fr": "French (Français)",
+		"de": "German (Deutsch)",
+		"it": "Italian (Italiano)",
+		"pt": "Portuguese (Português)",
+		"ru": "Russian (Русский)",
+		"ar": "Arabic (العربية)",
+		"hi": "Hindi (हिन्दी)",
+		"th": "Thai (ไทย)",
+		"vi": "Vietnamese (Tiếng Việt)",
+		"nl": "Dutch (Nederlands)",
+		"sv": "Swedish (Svenska)",
+		"no": "Norwegian (Norsk)",
+		"da": "Danish (Dansk)",
+		"fi": "Finnish (Suomi)",
+		"pl": "Polish (Polski)",
+		"tr": "Turkish (Türkçe)",
+		"he": "Hebrew (עברית)",
+		"id": "Indonesian (Bahasa Indonesia)",
+		"ms": "Malay (Bahasa Melayu)",
+		"ca": "Catalan (Català)",
+	}
+
+	if name, exists := languageNames[strings.ToLower(languageCode)]; exists {
+		return name
+	}
+	return languageCode
+}
+
+func createTranslateSystemMessage() string {
+	return `You are a professional translator specialized in translating markdown documents. When translating content, please follow these guidelines:
+
+1. Translate the content to the specified target language accurately and naturally
+2. Maintain the original markdown formatting and structure
+3. Preserve all headings, lists, code blocks, and formatting elements
+4. Keep the same tone and style as the original document
+5. Ensure technical terms are translated appropriately for the target language
+6. Maintain the document's readability and flow in the target language
+7. Preserve any links, references, or citations
+8. Keep the same level of detail and information as the original
+9. Use appropriate language conventions for the target language
+10. Ensure the translation sounds natural to native speakers of the target language`
+}
+
+func createTranslateUserMessage(content, language string) string {
+	return fmt.Sprintf(`Please translate the following markdown content to %s:
+
+%s
+
+Please maintain all markdown formatting, structure, and ensure the translation is natural and accurate in the target language.`, getLanguageName(language), content)
+}
+
+func saveTranslation(outputPath, translatedContent, originalPath, language string) error {
+	// ファイルに書き込み
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// 翻訳内容を直接書き込み
+	if _, err := f.WriteString(translatedContent); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -31,7 +31,7 @@ answer:
     7. Prefer rich markdown formatting
   
   # 目標文字数
-  target_chars: 500
+  target_length: 500
 
 # summarizeコマンドの設定
 summarize:
@@ -51,4 +51,21 @@ summarize:
     10. Maintain the original tone and style when appropriate
   
   # 目標文字数
-  target_chars: 800
+  target_length: 800
+
+# translateコマンドの設定
+translate:
+  # システムメッセージ
+  system_message: |
+    You are a professional translator specialized in translating markdown documents. When translating content, please follow these guidelines:
+
+    1. Translate the content to the specified target language accurately and naturally
+    2. Maintain the original markdown formatting and structure
+    3. Preserve all headings, lists, code blocks, and formatting elements
+    4. Keep the same tone and style as the original document
+    5. Ensure technical terms are translated appropriately for the target language
+    6. Maintain the document's readability and flow in the target language
+    7. Preserve any links, references, or citations
+    8. Keep the same level of detail and information as the original
+    9. Use appropriate language conventions for the target language
+    10. Ensure the translation sounds natural to native speakers of the target language

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Default   DefaultConfig   `yaml:"default"`
 	Answer    AnswerConfig    `yaml:"answer"`
 	Summarize SummarizeConfig `yaml:"summarize"`
+	Translate TranslateConfig `yaml:"translate"`
 }
 
 // DefaultConfig はデフォルト設定を表します
@@ -31,13 +32,18 @@ type QualityConfig struct {
 // AnswerConfig はanswerコマンドの設定を表します
 type AnswerConfig struct {
 	SystemMessage string `yaml:"system_message"`
-	TargetChars   int    `yaml:"target_chars"`
+	TargetLength  int    `yaml:"target_length"`
 }
 
 // SummarizeConfig はsummarizeコマンドの設定を表します
 type SummarizeConfig struct {
 	SystemMessage string `yaml:"system_message"`
-	TargetChars   int    `yaml:"target_chars"`
+	TargetLength  int    `yaml:"target_length"`
+}
+
+// TranslateConfig はtranslateコマンドの設定を表します
+type TranslateConfig struct {
+	SystemMessage string `yaml:"system_message"`
 }
 
 // LoadConfig は設定ファイルを読み込みます
@@ -83,12 +89,11 @@ func GetDefaultConfig() *Config {
 
 1. Answer in the same language as the question
 2. Make full use of the context information
-3. Provide specific and practical information
-4. Add examples and explanations when necessary
-5. Ensure answers are appropriately long and content-rich
-6. Provide insights that deepen the questioner's understanding
-7. Prefer rich markdown formatting`,
-			TargetChars: 500,
+3. Add examples and explanations when necessary
+4. Ensure answers are appropriately long and content-rich
+5. Provide insights that deepen the questioner's understanding
+6. Prefer rich markdown formatting`,
+			TargetLength: 500,
 		},
 		Summarize: SummarizeConfig{
 			SystemMessage: `You are a helpful and detailed assistant specialized in summarizing markdown documents. When summarizing content, please follow these guidelines:
@@ -103,7 +108,21 @@ func GetDefaultConfig() *Config {
 8. Keep the summary appropriately long - not too brief, not too verbose
 9. Focus on the most valuable and actionable information
 10. Maintain the original tone and style when appropriate`,
-			TargetChars: 800,
+			TargetLength: 800,
+		},
+		Translate: TranslateConfig{
+			SystemMessage: `You are a professional translator specialized in translating markdown documents. When translating content, please follow these guidelines:
+
+1. Translate the content to the specified target language accurately and naturally
+2. Maintain the original markdown formatting and structure
+3. Preserve all headings, lists, code blocks, and formatting elements
+4. Keep the same tone and style as the original document
+5. Ensure technical terms are translated appropriately for the target language
+6. Maintain the document's readability and flow in the target language
+7. Preserve any links, references, or citations
+8. Keep the same level of detail and information as the original
+9. Use appropriate language conventions for the target language
+10. Ensure the translation sounds natural to native speakers of the target language`,
 		},
 	}
 }


### PR DESCRIPTION
- 翻訳コマンドの実装
- README.md, INSTALL.md の英訳の作成と、既定ドキュメントを英語版に変更
- TargetChars を TargetLength と設定名を変更